### PR TITLE
Export 'sanitaryURI'

### DIFF
--- a/Text/HTML/SanitizeXSS.hs
+++ b/Text/HTML/SanitizeXSS.hs
@@ -16,6 +16,7 @@ module Text.HTML.SanitizeXSS
 
     -- * Utilities
     , sanitizeAttribute
+    , sanitaryURI
     ) where
 
 import Text.HTML.SanitizeXSS.Css


### PR DESCRIPTION
I need to sanitise the URIs of anchor tags and it would be helpful if I could reuse this predicate.
