### PR TITLE
text 2.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
     pull_request:
+        branches:
+        - master
     push:
         branches:
         - master
@@ -14,22 +16,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        resolver: [nightly, lts-15, lts-14, lts-12, lts-11, lts-9]
-        # Bugs in GHC make it crash too often to be worth running
-        exclude:
-          - os: macos-latest
-            resolver: lts-9
-          - os: windows-latest
-            resolver: lts-15
-          - os: windows-latest
-            resolver: nightly
+        resolver: [nightly, lts-21, lts-20, lts-19]
+        # # Bugs in GHC make it crash too often to be worth running
+        # exclude:
+        #   - os: macos-latest
+        #     resolver: lts-9
+        #   - os: windows-latest
+        #     resolver: lts-15
+        #   - os: windows-latest
+        #     resolver: nightly
 
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.stack
           key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
@@ -38,7 +40,8 @@ jobs:
 
       - name: Build and run tests
         shell: bash
-        run: |
-            set -ex
-            stack upgrade || curl -sSL https://get.haskellstack.org/ | sh -s - -f
-            stack test --bench --no-run-benchmarks --haddock --no-haddock-deps --no-terminal --resolver=${{ matrix.resolver }}
+        run: stack test --bench --no-run-benchmarks --haddock --no-haddock-deps --no-terminal --resolver=${{ matrix.resolver }}
+        # run: |
+        #     set -ex
+        #     stack upgrade || curl -sSL https://get.haskellstack.org/ | sh -s - -f
+        #     stack test --bench --no-run-benchmarks --haddock --no-haddock-deps --no-terminal --resolver=${{ matrix.resolver }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 cabal.sandbox.config
 .stack-work/
 xss-sanitize.cabal
+/dist-newstyle/
+/stack.yaml.lock

--- a/package.yaml
+++ b/package.yaml
@@ -21,7 +21,7 @@ dependencies:
 - tagsoup >=0.12.2 && <1
 - utf8-string >=0.3 && <1.1
 - css-text >=0.1.1 && <0.2
-- text >=0.11 && < 2.1
+- text >=0.11 && < 2.2
 - attoparsec >=0.10.0.3 && <1
 - network-uri >=2.6
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-18.10
+resolver: lts-20.26


### PR DESCRIPTION
- Bump CI and stack.yaml: CI looked very outdated so I showed it some love.
- Allow text-2.1 for GHC 9.8

Text bump published as revision 1 of xss-sanitize-0.3.7.2: https://hackage.haskell.org/package/xss-sanitize-0.3.7.2/revisions/
